### PR TITLE
task-7: authorization

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,54 +1,58 @@
-import React, {useState} from 'react';
-import {makeStyles} from '@material-ui/core/styles';
+import React, { useState } from "react";
+import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import axios from 'axios';
+import axios from "axios";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   content: {
     backgroundColor: theme.palette.background.paper,
-    padding: theme.spacing(3, 0, 3),
-  },
+    padding: theme.spacing(3, 0, 3)
+  }
 }));
 
 type CSVFileImportProps = {
-  url: string,
-  title: string
+  url: string;
+  title: string;
 };
 
-export default function CSVFileImport({url, title}: CSVFileImportProps) {
+export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   const classes = useStyles();
   const [file, setFile] = useState<any>();
 
   const onFileChange = (e: any) => {
     console.log(e);
-    let files = e.target.files || e.dataTransfer.files
-    if (!files.length) return
+    let files = e.target.files || e.dataTransfer.files;
+    if (!files.length) return;
     setFile(files.item(0));
   };
 
   const removeFile = () => {
-    setFile('');
+    setFile("");
   };
 
   const uploadFile = async (e: any) => {
-      // Get the presigned URL
-      const response = await axios({
-        method: 'GET',
-        url,
-        params: {
-          name: encodeURIComponent(file.name)
+    // Get the presigned URL
+    const response = await axios({
+      method: "PUT",
+      url,
+      ...(localStorage.getItem("authorization_token") && {
+        headers: {
+          Authorization: localStorage.getItem("authorization_token")
         }
-      })
-      console.log('File to upload: ', file.name)
-      console.log('Uploading to: ', response.data)
-      const result = await fetch(response.data, {
-        method: 'PUT',
-        body: file
-      })
-      console.log('Result: ', result)
-      setFile('');
-    }
-  ;
+      }),
+      params: {
+        name: encodeURIComponent(file.name)
+      }
+    });
+    console.log("File to upload: ", file.name);
+    console.log("Uploading to: ", response.data);
+    const result = await fetch(response.data, {
+      method: "PUT",
+      body: file
+    });
+    console.log("Result: ", result);
+    setFile("");
+  };
 
   return (
     <div className={classes.content}>
@@ -56,7 +60,7 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
         {title}
       </Typography>
       {!file ? (
-          <input type="file" onChange={onFileChange}/>
+        <input type="file" onChange={onFileChange} />
       ) : (
         <div>
           <button onClick={removeFile}>Remove file</button>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ axios.interceptors.response.use(
       error.response.status === 401 ||
       error.response.status === 403
     ) {
-      alert(error.response.data?.data);
+      alert(error.response.data?.message);
     }
     return Promise.reject(error.response);
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,23 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import 'index.css';
-import App from 'components/App/App';
-import {store} from 'store/store';
-import {Provider} from 'react-redux';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "index.css";
+import App from "components/App/App";
+import { store } from "store/store";
+import { Provider } from "react-redux";
+import * as serviceWorker from "./serviceWorker";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import axios from 'axios';
+import axios from "axios";
 
 axios.interceptors.response.use(
   response => {
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
+    if (
+      error.response.status === 400 ||
+      error.response.status === 401 ||
+      error.response.status === 403
+    ) {
       alert(error.response.data?.data);
     }
     return Promise.reject(error.response);
@@ -23,11 +27,11 @@ axios.interceptors.response.use(
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <CssBaseline/>
-      <App/>
+      <CssBaseline />
+      <App />
     </Provider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
- [x] 1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] 3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] 5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

**Additional (optional) tasks**
- [x] +1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

**Score 6/6**

**BE PR:** https://github.com/NikaOrl/node-aws-be/pull/5
**FE link:** https://d1q15wg20r97nf.cloudfront.net/admin/products

To authorize set 
`localStorage.setItem('authorization_token', 'Basic bmlrYW9ybDpURVNUX1BBU1NXT1JE=')`
to the browser console