### PR TITLE
Task 9

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
-  product: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev",
+  product: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/product",
   order: "https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev",
   import: "https://xreboz193f.execute-api.us-east-1.amazonaws.com/dev",
   bff: "https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev",
-  cart: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev"
+  cart: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/cart"
 };
 
 export default API_PATHS;

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
-  product: "https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev",
+  product: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev",
   order: "https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev",
   import: "https://xreboz193f.execute-api.us-east-1.amazonaws.com/dev",
   bff: "https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev",
-  cart: "https://5uuotor4l1.execute-api.us-east-1.amazonaws.com/develop/api"
+  cart: "https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev"
 };
 
 export default API_PATHS;


### PR DESCRIPTION
- [x] A working and correct express application should be in the bff-service folder. Reviewer can start this application locally with any valid configuration in the .env file and this application should works as described in the task 9.1
- [x] The bff-service should be deployed with Elastic Beanstalk. The bff-service call should be redirected to the appropriate service : product-service or CART. The response from the bff-service should be the same as if product-service or CART services were called directly.

### Additional (optional) tasks
- [x] Add a cache at the bff-service level for a request to the getProductsList function of the product-service. The cache should expire in 2 minutes.
- [x]  Use NestJS to create bff-service instead of express

**Score: 7/7**

**Product-service service API endpoint URL:**
https://sfuj8ilp8h.execute-api.us-east-1.amazonaws.com/dev/products

**Example of the create product API call with all needed information: URL, payload, headers, etc:**
![image](https://user-images.githubusercontent.com/29703381/102145315-0cff7d00-3e78-11eb-91be-eec30d6cd435.png)

**CART service API endpoint URL:**
https://5uuotor4l1.execute-api.us-east-1.amazonaws.com/develop/api/profile/cart

**bff-service service URL:**
https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/

**Example how to call product-service and CART services via bff-service service URL:**
https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/product/products
https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/product/products/4d900f89-25f8-4725-9415-15d2af94a80a
https://jchv8meix8.execute-api.us-east-1.amazonaws.com/dev/cart/profile/cart

**BE PR:** https://github.com/NikaOrl/node-aws-be/pull/6

**FE link with bff-service used:** https://d1q15wg20r97nf.cloudfront.net/